### PR TITLE
REFACTOR: move all meta data to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,38 @@
 [metadata]
-description-file = README.md
+# replace with your username:
+name = shopyo
+version = attr: shopyo.__version__
+url = https://shopyo.readthedocs.io/en/latest/
+project_urls =
+    Source Code = https://github.com/shopyo/shopyo/
+    Issue Tracker = https://github.com/shopyo/shopyo/issues
+    Twitter = https://twitter.com/shopyoproject
+license = MIT
+author = Abdur-Rahmaan Janhangeer
+author_email = arj.python@gmail.com
+description = Highly modular web framework built on top of Flask with Django advantages
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Environment :: Web Environment
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Intended Audience :: Developers
+    Development Status :: 4 - Beta
+
+[options]
+include_package_data = true
+python_requires = >=3.6
+packages = shopyo
+
+[options.entry_points]
+console_scripts =
+    shopyo = shopyo.api.cli:cli
+
+[flake8]
+max-line-length = 80

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,9 @@ https://github.com/pypa/sampleproject
 python setup.py publish to publish
 
 """
-
-# Always prefer setuptools over distutils
 from setuptools import setup
-
-# from setuptools import find_packages
-
 import os
 import sys
-from shopyo import __version__  # thanks gunicorn
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -24,67 +18,10 @@ if sys.argv[-1] == "publish":  # requests
     os.system("twine upload dist/* --skip-existing")
     sys.exit()
 
-# Get the long description from the README file
-with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
-    long_description = f.read()
 setup(
-    name="shopyo",  # Required
-    version=__version__,  # Required
-    description="Highly Modular Web Framework. Built For Big. Built on top of Flask with Django advantages",  # Optional
-    long_description=long_description,  # Optional
-    long_description_content_type="text/markdown",  # Optional (see note above)
-    url="https://github.com/shopyo/shopyo",  # Optional
-    author="Abdur-Rahmaan Janhangeer",  # Optional
-    author_email="arj.python@gmail.com",  # Optional
-    # Classifiers help users find your project by categorizing it.
-    #
-    # For a list of valid classifiers, see https://pypi.org/classifiers/
-    classifiers=[  # Optional
-        # How mature is this project? Common values are
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
-        "Development Status :: 4 - Beta",
-        # Indicate who your project is intended for
-        "Intended Audience :: Developers",
-        # 'Topic :: Weather',
-        # Pick your license as you wish
-        "License :: OSI Approved :: MIT License",
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        # These classifiers are *not* checked by 'pip install'. See instead
-        # 'python_requires' below.
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-    ],
-    keywords="flask django open web framework",  # Optional
-    # You can just specify package directories manually here if your project is
-    # simple. Or you can use find_packages().
-    #
-    # Alternatively, if you just want to distribute a single Python file, use
-    # the `py_modules` argument instead as follows, which will expect a file
-    # called `my_module.py` to exist:
-    #
-    #   py_modules=["my_module"],
-    #
-    # packages=find_packages(exclude=['contrib', 'docs', 'tests']),  # Required
-    packages=["shopyo"],
-    include_package_data=True,
-    python_requires=">=3.6",
     install_requires=open(
         os.path.join(here, "requirements.txt"), encoding="utf-8"
     )
     .read()
-    .split("\n"),  # Optional
-    project_urls={  # Optional
-        "Bug Reports": "https://github.com/shopyo/shopyo/issues",
-        "Source": "https://github.com/shopyo/shopyo/",
-    },
-    entry_points={
-        "console_scripts": [
-            "shopyo=shopyo.api.cli:cli"
-        ]
-    },
+    .split("\n")
 )

--- a/shopyo/api/tests/test_cli_integration.py
+++ b/shopyo/api/tests/test_cli_integration.py
@@ -11,11 +11,9 @@ pytestmark = pytest.mark.cli_integration
 
 @pytest.mark.usefixtures("restore_cwd")
 def test_initialise_after_new(tmp_path):
-    """run shopyo new inside a tmp directory foo,
-    create a venv, install the shopyo.tar.gz dependencies,
-    run `shopyo new` and then run `shopyo initialise`.
+    """run shopyo new inside a tmp directory foo, create a venv, install the
+    shopyo.tar.gz dependencies, then run `shopyo initialise`.
     """
-
     # go one level up to the cwd so we are are the root where
     # setup.py exits
     os.chdir("../")
@@ -25,6 +23,7 @@ def test_initialise_after_new(tmp_path):
     dist_path = os.path.join(os.getcwd(), "dist")
     shopyo_dist_name = f"shopyo-{__version__}.tar.gz"
     project_path = tmp_path / "foo"
+    print(project_path)
     # copy the shopyo dist to the test project path
     copytree(dist_path, os.path.join(project_path, "dist"))
     # change cwd to that of test project


### PR DESCRIPTION
* use `setup.cfg` for all everything where possible instead of setup.py. Keep `setup.py` to allow editable installs

fixes #5