### PR TITLE
FIX: flask related dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
 Flask==1.1.2
+click==7.1.2
+itsdangerous==1.1.0
+MarkupSafe==1.1.1
+Jinja2==2.11.3
 Flask-SQLAlchemy==2.4.4
 flask-marshmallow==0.14.0
 email-validator==1.1.1
@@ -6,6 +10,7 @@ Flask-Login==0.5.0
 Flask-Migrate==2.5.3
 Flask-WTF==0.14.3
 marshmallow-sqlalchemy==0.23.1
-flask-mailman==0.2.2
+flask-mailman==0.2.3
 flask-admin==1.5.7
 SQLAlchemy<1.4
+Werkzeug==1.0.1


### PR DESCRIPTION
* latest pallets update for `flask`, `marksafeup`, `werkzeug`, `Jinja`, etc causing current tests to fail. Freezing dependencies to support old version for now but support for flask 2.0 to come in near future

fixes #29